### PR TITLE
Initialize Instagram analytics dashboard scaffold

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ig-analytics-backend",
+  "type": "module",
+  "dependencies": {
+    "axios": "^1.7.7",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "pg": "^8.12.0",
+    "sentiment": "^5.0.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  },
+  "scripts": {
+    "dev": "node --env-file=.env ./dist/api/server.js",
+    "ingest": "node --env-file=.env ./dist/ingest/jobs.js"
+  }
+}

--- a/backend/src/api/server.ts
+++ b/backend/src/api/server.ts
@@ -1,0 +1,52 @@
+import express from 'express';
+import cors from 'cors';
+import { Pool } from 'pg';
+
+const app = express();
+app.use(cors());
+const db = new Pool();
+
+app.get('/api/metrics/overview', async (req, res) => {
+  const { from, to } = req.query as any;
+  const rows = await db.query(
+    `SELECT day,
+            mentions, pos, neg, neu,
+            est_reach, likes, comments, unique_authors
+       FROM ig_daily_metrics
+      WHERE brand_id = 1 AND day BETWEEN $1 AND $2
+      ORDER BY day`, [from, to]
+  );
+
+  const total = rows.rows.reduce((acc, r) => ({
+    mentions: acc.mentions + r.mentions,
+    pos: acc.pos + r.pos, neg: acc.neg + r.neg, neu: acc.neu + r.neu,
+    est_reach: acc.est_reach + Number(r.est_reach),
+    likes: acc.likes + Number(r.likes), comments: acc.comments + Number(r.comments)
+  }), {mentions:0,pos:0,neg:0,neu:0,est_reach:0,likes:0,comments:0});
+
+  res.json({ total, series: rows.rows });
+});
+
+app.get('/api/mentions/latest', async (req, res) => {
+  const limit = Number(req.query.limit || 20);
+  const rows = await db.query(
+    `SELECT m.created_at, m.matched_as, p.permalink, p.caption, p.like_count, p.comment_count
+       FROM ig_mention m
+       JOIN ig_post p ON p.media_id = m.media_id
+      ORDER BY m.created_at DESC
+      LIMIT $1`, [limit]
+  );
+  res.json(rows.rows);
+});
+
+app.get('/api/sentiment/series', async (req, res) => {
+  const { from, to } = req.query as any;
+  const rows = await db.query(
+    `SELECT day, pos, neg, neu FROM ig_daily_metrics
+      WHERE brand_id=1 AND day BETWEEN $1 AND $2 ORDER BY day`, [from, to]
+  );
+  res.json(rows.rows);
+});
+
+const port = process.env.PORT || 4001;
+app.listen(port, () => console.log('API listening on', port));

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,5 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export default process.env;

--- a/backend/src/config/provider.ts
+++ b/backend/src/config/provider.ts
@@ -1,0 +1,40 @@
+export type ProviderProfile = {
+  name: string;
+  host: string; // RAPIDAPI_HOST
+  paths: {
+    userByUsername: (u: string) => string;
+    userPosts: (id: string, cursor?: string) => string;
+    mediaComments: (id: string, cursor?: string) => string;
+    searchHashtag: (tag: string, cursor?: string) => string;
+  };
+};
+
+export const PROVIDERS: Record<string, ProviderProfile> = {
+  // Example: instagram188 (widely used on RapidAPI; verify docs)
+  instagram188: {
+    name: 'instagram188',
+    host: process.env.RAPIDAPI_HOST || 'instagram188.p.rapidapi.com',
+    paths: {
+      userByUsername: (u) => `/user/info?username=${encodeURIComponent(u)}`,
+      userPosts: (id, cursor) => `/user/posts?userid=${id}${cursor ? `&end_cursor=${cursor}` : ''}`,
+      mediaComments: (id, cursor) => `/media/comments?media_id=${id}${cursor ? `&end_cursor=${cursor}` : ''}`,
+      searchHashtag: (tag, cursor) => `/hashtag/medias?hashtag=${encodeURIComponent(tag)}${cursor ? `&end_cursor=${cursor}` : ''}`,
+    },
+  },
+
+  // Skeleton for another provider; fill with its docs.
+  generic: {
+    name: 'generic',
+    host: process.env.RAPIDAPI_HOST || 'your-provider.p.rapidapi.com',
+    paths: {
+      userByUsername: (u) => `/v1/user?username=${encodeURIComponent(u)}`,
+      userPosts: (id, cursor) => `/v1/user/${id}/posts${cursor ? `?cursor=${cursor}` : ''}`,
+      mediaComments: (id, cursor) => `/v1/media/${id}/comments${cursor ? `?cursor=${cursor}` : ''}`,
+      searchHashtag: (tag, cursor) => `/v1/hashtag/${encodeURIComponent(tag)}/posts${cursor ? `?cursor=${cursor}` : ''}`,
+    },
+  },
+};
+
+export function pickProvider(key = process.env.PROVIDER_PROFILE || 'instagram188'): ProviderProfile {
+  return PROVIDERS[key];
+}

--- a/backend/src/db/pool.ts
+++ b/backend/src/db/pool.ts
@@ -1,0 +1,4 @@
+import { Pool } from 'pg';
+
+const pool = new Pool();
+export default pool;

--- a/backend/src/db/sql/01_core.sql
+++ b/backend/src/db/sql/01_core.sql
@@ -1,0 +1,68 @@
+-- 01_core.sql
+CREATE TABLE IF NOT EXISTS brand (
+  brand_id SERIAL PRIMARY KEY,
+  handle TEXT UNIQUE NOT NULL,
+  aliases TEXT[] NOT NULL DEFAULT '{}'::TEXT[]
+);
+
+CREATE TABLE IF NOT EXISTS ig_account (
+  ig_user_id TEXT PRIMARY KEY,
+  username TEXT NOT NULL,
+  full_name TEXT,
+  followers INTEGER,
+  scraped_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS ig_post (
+  media_id TEXT PRIMARY KEY,
+  code TEXT,
+  owner_id TEXT REFERENCES ig_account(ig_user_id),
+  taken_at TIMESTAMPTZ,
+  caption TEXT,
+  like_count INTEGER,
+  comment_count INTEGER,
+  permalink TEXT,
+  raw JSONB,
+  scraped_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ig_post_taken_at_idx ON ig_post(taken_at DESC);
+CREATE INDEX IF NOT EXISTS ig_post_gin_raw ON ig_post USING GIN (raw);
+
+CREATE TABLE IF NOT EXISTS ig_comment (
+  comment_id TEXT PRIMARY KEY,
+  media_id TEXT REFERENCES ig_post(media_id) ON DELETE CASCADE,
+  author_id TEXT REFERENCES ig_account(ig_user_id),
+  text TEXT,
+  created_at TIMESTAMPTZ,
+  sentiment SMALLINT,
+  raw JSONB,
+  scraped_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ig_comment_media_idx ON ig_comment(media_id);
+CREATE INDEX IF NOT EXISTS ig_comment_created_idx ON ig_comment(created_at DESC);
+
+CREATE TYPE mention_source AS ENUM ('caption', 'comment', 'hashtag');
+CREATE TABLE IF NOT EXISTS ig_mention (
+  id BIGSERIAL PRIMARY KEY,
+  media_id TEXT REFERENCES ig_post(media_id) ON DELETE CASCADE,
+  source mention_source NOT NULL,
+  matched_as TEXT NOT NULL,
+  author_id TEXT,
+  created_at DATE NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ig_mention_created_idx ON ig_mention(created_at);
+
+CREATE TABLE IF NOT EXISTS ig_daily_metrics (
+  brand_id INTEGER REFERENCES brand(brand_id),
+  day DATE NOT NULL,
+  mentions INTEGER NOT NULL DEFAULT 0,
+  pos INTEGER NOT NULL DEFAULT 0,
+  neg INTEGER NOT NULL DEFAULT 0,
+  neu INTEGER NOT NULL DEFAULT 0,
+  est_reach BIGINT NOT NULL DEFAULT 0,
+  likes BIGINT NOT NULL DEFAULT 0,
+  comments BIGINT NOT NULL DEFAULT 0,
+  unique_authors INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (brand_id, day)
+);

--- a/backend/src/ingest/jobs.ts
+++ b/backend/src/ingest/jobs.ts
@@ -1,0 +1,102 @@
+import { Pool } from 'pg';
+import { searchByHashtag, iterateMediaComments } from '../services/instagram';
+import { triSentiment } from '../utils/sentiment';
+
+const pool = new Pool();
+
+const aliases = (process.env.BRAND_ALIASES||'').split(',').map(s=>s.trim()).filter(Boolean);
+
+function matchAlias(text: string): string | null {
+  const t = (text||'').toLowerCase();
+  for (const a of aliases) {
+    if (!a) continue; const q = a.toLowerCase();
+    if (t.includes(q.replace(/^#/,'').replace(/^@/,'')) || t.includes(q)) return a;
+  }
+  return null;
+}
+
+export async function ingestByHashtags() {
+  // Pull by every alias that is a hashtag
+  const tags = aliases.filter(a=>a.startsWith('#')).map(a=>a.slice(1));
+  for (const tag of tags) {
+    for await (const post of searchByHashtag(tag, 500)) {
+      const media_id = post?.id || post?.media?.id || post?.pk || post?.code;
+      const owner_id = post?.owner?.id || post?.user?.id || post?.owner_id;
+      const taken_at = new Date(post?.taken_at || post?.timestamp || Date.now());
+      const caption = post?.caption?.text || post?.caption || '';
+      const like_count = post?.like_count ?? post?.likes ?? 0;
+      const comment_count = post?.comment_count ?? post?.comments_count ?? 0;
+      const permalink = post?.permalink || post?.link || '';
+
+      await pool.query(
+        `INSERT INTO ig_post (media_id, code, owner_id, taken_at, caption, like_count, comment_count, permalink, raw)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+         ON CONFLICT (media_id) DO UPDATE SET
+           like_count=EXCLUDED.like_count,
+           comment_count=EXCLUDED.comment_count,
+           raw=EXCLUDED.raw`,
+        [media_id, post?.code||null, owner_id, taken_at, caption, like_count, comment_count, permalink, post]
+      );
+
+      const m = matchAlias(caption);
+      if (m) {
+        await pool.query(
+          `INSERT INTO ig_mention (media_id, source, matched_as, author_id, created_at)
+           VALUES ($1,'caption',$2,$3,$4)`,
+          [media_id, m, owner_id, taken_at.toISOString().slice(0,10)]
+        );
+      }
+
+      // Comments
+      let authors = new Set<string>();
+      let pos=0, neg=0, neu=0;
+      for await (const c of iterateMediaComments(media_id, 500)) {
+        const comment_id = c?.id || c?.pk || `${media_id}:${c?.user_id}:${c?.created_at}`;
+        const author_id = c?.user_id || c?.user?.id || c?.owner_id || null;
+        const text = c?.text || '';
+        const created = new Date(c?.created_at || c?.timestamp || Date.now());
+        const s = triSentiment(text);
+        if (s>0) pos++; else if (s<0) neg++; else neu++;
+        if (author_id) authors.add(String(author_id));
+
+        await pool.query(
+          `INSERT INTO ig_comment (comment_id, media_id, author_id, text, created_at, sentiment, raw)
+           VALUES ($1,$2,$3,$4,$5,$6,$7)
+           ON CONFLICT (comment_id) DO NOTHING`,
+          [comment_id, media_id, author_id, text, created, s, c]
+        );
+
+        const m2 = matchAlias(text);
+        if (m2) {
+          await pool.query(
+            `INSERT INTO ig_mention (media_id, source, matched_as, author_id, created_at)
+             VALUES ($1,'comment',$2,$3,$4)`,
+            [media_id, m2, author_id, created.toISOString().slice(0,10)]
+          );
+        }
+      }
+
+      // Daily rollup update
+      await pool.query(
+        `INSERT INTO ig_daily_metrics (brand_id, day, mentions, pos, neg, neu, est_reach, likes, comments, unique_authors)
+         VALUES (1, $1,
+                 (SELECT COUNT(*) FROM ig_mention WHERE media_id=$2),
+                 $3,$4,$5,
+                 COALESCE($6,0),
+                 $7,$8,$9)
+         ON CONFLICT (brand_id, day) DO UPDATE SET
+           mentions = ig_daily_metrics.mentions + EXCLUDED.mentions,
+           pos = ig_daily_metrics.pos + EXCLUDED.pos,
+           neg = ig_daily_metrics.neg + EXCLUDED.neg,
+           neu = ig_daily_metrics.neu + EXCLUDED.neu,
+           est_reach = ig_daily_metrics.est_reach + EXCLUDED.est_reach,
+           likes = ig_daily_metrics.likes + EXCLUDED.likes,
+           comments = ig_daily_metrics.comments + EXCLUDED.comments,
+           unique_authors = GREATEST(ig_daily_metrics.unique_authors, EXCLUDED.unique_authors)`,
+        [taken_at.toISOString().slice(0,10), media_id, pos, neg, neu,
+         (post?.owner?.followers || post?.user?.follower_count || (like_count + 4*comment_count)),
+         like_count, comment_count, authors.size]
+      );
+    }
+  }
+}

--- a/backend/src/metrics/compute.ts
+++ b/backend/src/metrics/compute.ts
@@ -1,0 +1,5 @@
+// Placeholder for additional metrics computations
+export function computeExtraMetrics() {
+  // implement custom reducers here
+  return {};
+}

--- a/backend/src/providers/rapidapi.ts
+++ b/backend/src/providers/rapidapi.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import { pickProvider } from '../config/provider';
+
+const provider = pickProvider();
+
+export const http = axios.create({
+  baseURL: `https://${provider.host}`,
+  timeout: 20000,
+  headers: {
+    'X-RapidAPI-Key': process.env.RAPIDAPI_KEY!,
+    'X-RapidAPI-Host': provider.host,
+  },
+});
+
+export async function rq<T = any>(path: string, params?: Record<string, any>) {
+  const { data } = await http.get<T>(path, { params });
+  return data as T;
+}

--- a/backend/src/services/instagram.ts
+++ b/backend/src/services/instagram.ts
@@ -1,0 +1,44 @@
+import { rq } from '../providers/rapidapi';
+import { pickProvider } from '../config/provider';
+
+const P = pickProvider();
+
+export async function getUserByUsername(username: string) {
+  return rq(P.paths.userByUsername(username));
+}
+
+export async function *iterateUserPosts(userId: string, limit = 300) {
+  let cursor: string | undefined;
+  let fetched = 0;
+  while (fetched < limit) {
+    const res: any = await rq(P.paths.userPosts(userId, cursor));
+    const items = res?.items || res?.data || res?.result || [];
+    for (const it of items) { yield it; fetched++; if (fetched >= limit) return; }
+    cursor = res?.next_cursor || res?.end_cursor || res?.paging?.cursors?.after;
+    if (!cursor) break;
+  }
+}
+
+export async function *iterateMediaComments(mediaId: string, limit = 500) {
+  let cursor: string | undefined;
+  let fetched = 0;
+  while (fetched < limit) {
+    const res: any = await rq(P.paths.mediaComments(mediaId, cursor));
+    const items = res?.items || res?.data || res?.result || [];
+    for (const it of items) { yield it; fetched++; if (fetched >= limit) return; }
+    cursor = res?.next_cursor || res?.end_cursor || res?.paging?.cursors?.after;
+    if (!cursor) break;
+  }
+}
+
+export async function *searchByHashtag(tag: string, limit = 400) {
+  let cursor: string | undefined;
+  let fetched = 0;
+  while (fetched < limit) {
+    const res: any = await rq(P.paths.searchHashtag(tag, cursor));
+    const items = res?.items || res?.data || res?.result || [];
+    for (const it of items) { yield it; fetched++; if (fetched >= limit) return; }
+    cursor = res?.next_cursor || res?.end_cursor || res?.paging?.cursors?.after;
+    if (!cursor) break;
+  }
+}

--- a/backend/src/utils/sentiment.ts
+++ b/backend/src/utils/sentiment.ts
@@ -1,0 +1,8 @@
+import Sentiment from 'sentiment';
+const s = new Sentiment();
+
+export function triSentiment(text: string): -1 | 0 | 1 {
+  if (!text) return 0;
+  const score = s.analyze(text).score;
+  return score > 0 ? 1 : score < 0 ? -1 : 0;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/frontend/app/(dashboard)/page.tsx
+++ b/frontend/app/(dashboard)/page.tsx
@@ -1,0 +1,5 @@
+import InstagramAnalyticsDashboard from '../../components/InstagramAnalyticsDashboard';
+
+export default function Page() {
+  return <InstagramAnalyticsDashboard />;
+}

--- a/frontend/components/InstagramAnalyticsDashboard.tsx
+++ b/frontend/components/InstagramAnalyticsDashboard.tsx
@@ -1,0 +1,94 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+async function fetchJSON(url: string) { const r = await fetch(url); return r.json(); }
+
+export default function InstagramAnalyticsDashboard() {
+  const [overview, setOverview] = useState<any>(null);
+  const [sentSeries, setSentSeries] = useState<any[]>([]);
+  const [latest, setLatest] = useState<any[]>([]);
+
+  const from = new Date(Date.now() - 27*24*3600*1000).toISOString().slice(0,10);
+  const to = new Date().toISOString().slice(0,10);
+
+  useEffect(() => {
+    fetchJSON(`/api/metrics/overview?from=${from}&to=${to}`).then(setOverview);
+    fetchJSON(`/api/sentiment/series?from=${from}&to=${to}`).then(setSentSeries);
+    fetchJSON(`/api/mentions/latest?limit=12`).then(setLatest);
+  }, []);
+
+  const kpi = overview?.total || {mentions:0, est_reach:0, likes:0, comments:0, pos:0, neg:0, neu:0};
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <Kpi title="Mentions" value={kpi.mentions} />
+        <Kpi title="Est. Reach" value={kpi.est_reach} />
+        <Kpi title="Likes" value={kpi.likes} />
+        <Kpi title="Comments" value={kpi.comments} />
+        <Kpi title="Pos/Neg" value={`${kpi.pos}/${kpi.neg}`} />
+      </div>
+
+      {/* Mentions over time */}
+      <Section title="Mentions (Last 28 days)">
+        <ResponsiveContainer width="100%" height={240}>
+          <BarChart data={overview?.series || []}>
+            <XAxis dataKey="day" hide={false} />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="mentions" name="Mentions" />
+          </BarChart>
+        </ResponsiveContainer>
+      </Section>
+
+      {/* Sentiment stacked */}
+      <Section title="Sentiment">
+        <ResponsiveContainer width="100%" height={240}>
+          <BarChart data={sentSeries}>
+            <XAxis dataKey="day" />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="pos" stackId="a" name="Positive" />
+            <Bar dataKey="neu" stackId="a" name="Neutral" />
+            <Bar dataKey="neg" stackId="a" name="Negative" />
+          </BarChart>
+        </ResponsiveContainer>
+      </Section>
+
+      {/* Latest mentions */}
+      <Section title="Latest Mentions">
+        <div className="grid md:grid-cols-2 gap-3">
+          {latest.map((x, i) => (
+            <div key={i} className="border rounded-2xl p-3 shadow-sm">
+              <div className="text-sm text-gray-500">{x.created_at}</div>
+              <div className="font-semibold line-clamp-2">{x.caption}</div>
+              <div className="text-xs text-gray-500">{x.matched_as} · ❤ {x.like_count} · 💬 {x.comment_count}</div>
+              {x.permalink && <a className="text-xs underline" href={x.permalink} target="_blank">open</a>}
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function Kpi({title, value}:{title:string; value:any}) {
+  return (
+    <div className="rounded-2xl p-4 border shadow-sm">
+      <div className="text-sm text-gray-500">{title}</div>
+      <div className="text-2xl font-bold">{value}</div>
+    </div>
+  );
+}
+function Section({title, children}:{title:string; children:any}){
+  return (
+    <section className="space-y-2">
+      <h3 className="font-semibold">{title}</h3>
+      {children}
+    </section>
+  );
+}

--- a/frontend/lib/fetcher.ts
+++ b/frontend/lib/fetcher.ts
@@ -1,0 +1,5 @@
+export async function api(path: string) {
+  const base = process.env.NEXT_PUBLIC_BACKEND || 'http://localhost:4001';
+  const r = await fetch(`${base}${path}`, { cache: 'no-store' });
+  return r.json();
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ig-analytics-frontend",
+  "type": "module",
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "recharts": "^2.7.2"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.5"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "next/core-web-vitals",
+  "compilerOptions": {
+    "strict": false,
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold backend with provider adapter, ingest job, API routes and sentiment utility
- add PostgreSQL schema and configuration
- scaffold Next.js dashboard for displaying KPIs and sentiment

## Testing
- `npm --prefix backend test` *(fails: Missing script 'test')*
- `npm --prefix frontend test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68aba8b6cb6c832785d1a1512826d92b