### PR TITLE
feat: switch to social-api4 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ frontend/ # Next.js dashboard for metrics visualization
 3. Provide environment variables in `backend/.env`:
    - `RAPIDAPI_KEY` – RapidAPI key for Instagram provider
    - `RAPIDAPI_HOST` – (optional) override provider host
-   - `PROVIDER_PROFILE` – (optional) provider profile name, defaults to `instagram188`
+   - `PROVIDER_PROFILE` – (optional) provider profile name, defaults to `social-api4`
    - `BRAND_ALIASES` – comma-separated list of hashtags/usernames to track
    - standard `pg` settings for PostgreSQL (`PGHOST`, `PGDATABASE`, `PGUSER`, etc.)
 4. Start the API server:

--- a/backend/src/config/provider.ts
+++ b/backend/src/config/provider.ts
@@ -10,10 +10,10 @@ export type ProviderProfile = {
 };
 
 export const PROVIDERS: Record<string, ProviderProfile> = {
-  // Example: instagram188 (widely used on RapidAPI; verify docs)
-  instagram188: {
-    name: 'instagram188',
-    host: process.env.RAPIDAPI_HOST || 'instagram188.p.rapidapi.com',
+  // RapidAPI Social API4 provider
+  'social-api4': {
+    name: 'social-api4',
+    host: process.env.RAPIDAPI_HOST || 'social-api4.p.rapidapi.com',
     paths: {
       userByUsername: (u) => `/user/info?username=${encodeURIComponent(u)}`,
       userPosts: (id, cursor) => `/user/posts?userid=${id}${cursor ? `&end_cursor=${cursor}` : ''}`,
@@ -35,6 +35,6 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
   },
 };
 
-export function pickProvider(key = process.env.PROVIDER_PROFILE || 'instagram188'): ProviderProfile {
+export function pickProvider(key = process.env.PROVIDER_PROFILE || 'social-api4'): ProviderProfile {
   return PROVIDERS[key];
 }


### PR DESCRIPTION
## Summary
- use Social API4 RapidAPI host for Instagram data
- update docs to reflect new default provider profile

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68abab39f7848327a2cc3a5ed7759cf6