### PR TITLE
Add backend build script and document build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ frontend/ # Next.js dashboard for metrics visualization
    cd backend
    npm install
    ```
-2. Compile the TypeScript sources:
+2. Build the TypeScript sources:
    ```bash
-   npx tsc
+   npm run build
    ```
 3. Provide environment variables in `backend/.env`:
    - `RAPIDAPI_KEY` – RapidAPI key for Instagram provider

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "typescript": "^5.4.5"
   },
   "scripts": {
-    "dev": "node --env-file=.env ./dist/api/server.js",
+    "dev": "npm run build && node --env-file=.env ./dist/api/server.js",
+    "build": "tsc",
     "ingest": "node --env-file=.env ./dist/ingest/jobs.js"
   }
 }


### PR DESCRIPTION
## Summary
- add a `build` script invoking TypeScript compiler
- run the build before starting the backend server
- document build step in README backend setup instructions

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm run build` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68abf05cca3483278afb980737baa242