### PR TITLE
Add PM2 ecosystem configuration

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,30 @@
+module.exports = {
+  apps: [
+    {
+      name: "insta-backend",
+      cwd: "./backend",
+      script: "npm",
+      args: "run dev",
+      env: { NODE_ENV: "development" },
+      env_production: { NODE_ENV: "production" },
+      autorestart: true,
+      max_restarts: 5,
+      time: true
+    },
+    {
+      name: "insta-frontend",
+      cwd: "./frontend",
+      script: "npm",
+      args: "run dev",
+      env: {
+        NODE_ENV: "development",
+        // atau pakai .env.local di frontend
+        NEXT_PUBLIC_API_URL: "http://localhost:4001"
+      },
+      env_production: { NODE_ENV: "production", PORT: 3000 },
+      autorestart: true,
+      max_restarts: 5,
+      time: true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add PM2 ecosystem configuration for backend and frontend apps

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68abf24d65fc8327aea18ee7581c2526