### PR TITLE
Fix frontend API calls to backend

### DIFF
--- a/frontend/components/InstagramAnalyticsDashboard.tsx
+++ b/frontend/components/InstagramAnalyticsDashboard.tsx
@@ -1,8 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-
-async function fetchJSON(url: string) { const r = await fetch(url); return r.json(); }
+import { api } from '../lib/fetcher';
 
 export default function InstagramAnalyticsDashboard() {
   const [overview, setOverview] = useState<any>(null);
@@ -13,9 +12,9 @@ export default function InstagramAnalyticsDashboard() {
   const to = new Date().toISOString().slice(0,10);
 
   useEffect(() => {
-    fetchJSON(`/api/metrics/overview?from=${from}&to=${to}`).then(setOverview);
-    fetchJSON(`/api/sentiment/series?from=${from}&to=${to}`).then(setSentSeries);
-    fetchJSON(`/api/mentions/latest?limit=12`).then(setLatest);
+    api(`/api/metrics/overview?from=${from}&to=${to}`).then(setOverview);
+    api(`/api/sentiment/series?from=${from}&to=${to}`).then(setSentSeries);
+    api(`/api/mentions/latest?limit=12`).then(setLatest);
   }, []);
 
   const kpi = overview?.total || {mentions:0, est_reach:0, likes:0, comments:0, pos:0, neg:0, neu:0};

--- a/frontend/lib/fetcher.ts
+++ b/frontend/lib/fetcher.ts
@@ -1,5 +1,8 @@
 export async function api(path: string) {
-  const base = process.env.NEXT_PUBLIC_BACKEND || 'http://localhost:4001';
-  const r = await fetch(`${base}${path}`, { cache: 'no-store' });
-  return r.json();
+  const base = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4001';
+  const res = await fetch(`${base}${path}`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error(`API request failed with status ${res.status}`);
+  }
+  return res.json();
 }


### PR DESCRIPTION
## Summary
- load API base URL from `NEXT_PUBLIC_API_URL`
- throw error when backend response is not ok
- use shared API helper in Instagram analytics dashboard

## Testing
- `cd backend && npm test` *(fails: Missing script: "test")*
- `npm run build` (backend)
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: File 'next/core-web-vitals' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac673cdb888327b5103c375b6d0b1e