### PR TITLE
fix: correct TypeScript configuration for Next.js

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "next/core-web-vitals",
   "compilerOptions": {
     "strict": false,
     "baseUrl": "."
-  }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- fix TypeScript config by removing invalid `next/core-web-vitals` extend and specifying includes/excludes
- add Next.js type definitions file

## Testing
- `npm run build` *(fails: (dashboard)/page.tsx doesn't have a root layout)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7efa8e048327acdc8bec7fc57969