### PR TITLE
chore: add tailwind design tokens and global styles

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply antialiased bg-neutral-50 text-neutral-900;
+  line-height: 1.45;
+}
+
+h1,h2,h3,h4,h5,h6 {
+  line-height: 1.2;
+}
+
+:focus-visible {
+  outline: 2px solid #111827;
+  outline-offset: 2px;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,12 @@
+import "./globals.css";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"] });
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className={inter.className}>{children}</body>
     </html>
   );
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.11",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "autoprefixer": "^10.4.16"
   },
   "scripts": {
     "dev": "next dev",

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {
+      fontFamily: { sans: ["Inter", "system-ui", "sans-serif"] },
+      borderRadius: { xl: "16px", "2xl": "20px" },
+      colors: {
+        brand: { DEFAULT: "#4F46E5", lite: "#EEF2FF" },
+      },
+      boxShadow: {
+        soft: "0 1px 2px rgba(0,0,0,.06), 0 4px 12px rgba(0,0,0,.04)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add Tailwind config with brand tokens and custom shadow
- wire up Inter font and base globals
- add PostCSS setup for Tailwind

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68adbfa7cadc832782a3aebb7377e9ad