### PR TITLE
Ensure standard Node environment for Next.js

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,8 +17,8 @@
     "autoprefixer": "^10.4.16"
   },
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_ENV=development next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "NODE_ENV=production next start"
   }
 }


### PR DESCRIPTION
## Summary
- force dev script to run with NODE_ENV=development
- ensure start script sets NODE_ENV=production

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68adc7349df88327b73bfc725619066d